### PR TITLE
Add support for emacs

### DIFF
--- a/note
+++ b/note
@@ -41,7 +41,7 @@ open_note () {
         $EDITOR "+normal G$" +startinsert $note_path
     elif [[ $EDITOR = *"emacs"* ]]; then
         # If no default editor, use Vim and open in insert mode.
-        emacs -nw $note_path
+        emacs -nw $note_path --eval "(goto-char (point-max))"
     elif [[ $EDITOR = "" ]]; then
         # If no default editor, use Vim and open in insert mode.
         vim "+normal G$" +startinsert $note_path

--- a/note
+++ b/note
@@ -39,6 +39,9 @@ open_note () {
     if [[ $EDITOR = *"vim"* ]] || [[ $EDITOR = *"nvim"* ]]; then
         # Open Vim or Neovim in insert mode.
         $EDITOR "+normal G$" +startinsert $note_path
+    elif [[ $EDITOR = *"emacs"* ]]; then
+        # If no default editor, use Vim and open in insert mode.
+        emacs -nw $note_path
     elif [[ $EDITOR = "" ]]; then
         # If no default editor, use Vim and open in insert mode.
         vim "+normal G$" +startinsert $note_path


### PR DESCRIPTION
If $EDITOR is set to emacs, then the note will open in emacs in the terminal. Also, the text cursor will be moved to the end of the note, so the user can begin adding new text to the note file right away.