### PR TITLE
Fix bug when vim opens in insert mode.

### DIFF
--- a/note
+++ b/note
@@ -23,7 +23,7 @@ print_info () {
 }
 
 print_help () {
-    printf "note - Note Keeper 0.3 (02 Aug 2018)
+    printf "note - Note Keeper 0.3.1 (14 Feb 2019)
 
 Usage: note [arguments]
 
@@ -38,13 +38,13 @@ Arguments:
 open_note () {
     if [[ $EDITOR = *"vim"* ]] || [[ $EDITOR = *"nvim"* ]]; then
         # Open Vim or Neovim in insert mode.
-        $EDITOR "+normal G$" +startinsert $note_path
+        $EDITOR "+normal G$" +startinsert! $note_path
     elif [[ $EDITOR = *"emacs"* ]]; then
         # Open Emacs with cursor at EOF.
         emacs -nw $note_path --eval "(goto-char (point-max))"
     elif [[ $EDITOR = "" ]]; then
         # If no default editor, use Vim and open in insert mode.
-        vim "+normal G$" +startinsert $note_path
+        vim "+normal G$" +startinsert! $note_path
     else
         $EDITOR $note_path
     fi


### PR DESCRIPTION
Before, it would open in insert mode and place the cursor
before the last character. Now it opens in insert mode and
correctly places the cursor at the end of the file/line.

Updated version to 0.3.1

Resolves #17 