### PR TITLE
Update directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ note file in Vim.
 * The default location to store notes is in the `~/notes/` directory.
   * To change this, set a `NOTE_DIR` value in your `noterc` file.
 
-  create the file `${XDG_CONFIG_HOME}/notekeeper/noterc`
 
 ### noterc
 
@@ -107,7 +106,7 @@ You can use a `noterc` file to customize Notekeeper!
 The following variables can be set to overwrite Notekeeper defaults:
 
 * `NOTE_DIR` - The base directory for storing notes.
-  * Default is `$HOME/notes`
+  * Default is `~/notes`
 
 * `EDITOR`
   * By default Notekeeper uses whatever is in your `$EDITOR` variable, and falls back to vim if none is set.

--- a/README.md
+++ b/README.md
@@ -73,15 +73,18 @@ note file in Vim.
 ## File Organization
 
 ```shell
-$ tree ~/notes
+❱❱ tree ~/notes
 /home/username/notes
-└── 2018
-    ├── 07
-    │   └── 31.md
-    └── 08
-        ├── 01.md
-        └── 02.md
-
+└── 2020
+    ├── 06
+    │   ├── 21
+    │   │   └── 2020-06-21.md
+    │   └── 22
+    │       └── 2020-06-22.md
+    └── 07
+        └── 28
+            ├── 2020-07-28.md
+            └── another-note.md
 ```
 
 ## Configuration
@@ -90,14 +93,24 @@ $ tree ~/notes
   * If no default editor is set, it will use *Vim*.
     * It opens *vim* in insert mode.
 * The default location to store notes is in the `~/notes/` directory.
-  * To change this, create the file `${XDG_CONFIG_HOME:-$HOME}/notekeeper/noterc`
+  * To change this, set a `NOTE_DIR` value in your `noterc` file.
 
-### noterc Variables
+  create the file `${XDG_CONFIG_HOME}/notekeeper/noterc`
 
-```shell
-# Directory where the current note should be stored
-NOTE_DIR="$HOME/notes/$YEAR/$MONTH"
+### noterc
 
-# Name of the Note
-NOTE_NAME="$DAY.md"
-```
+You can use a `noterc` file to customize Notekeeper!
+
+* Create this file at `${XDG_CONFIG_HOME}/notekeeper/noterc`
+  * On MacOS, this will be `~/.config/notekeeper/noterc`
+
+The following variables can be set to overwrite Notekeeper defaults:
+
+* `NOTE_DIR` - The base directory for storing notes.
+  * Default is `$HOME/notes`
+
+* `EDITOR`
+  * By default Notekeeper uses whatever is in your `$EDITOR` variable, and falls back to vim if none is set.
+
+* `NOTE_NAME`
+  * Default is `$YEAR-$MONTH-$DAY.md`

--- a/note
+++ b/note
@@ -3,11 +3,13 @@
 YEAR=$(date +'%Y')
 MONTH=$(date +'%m')
 DAY=$(date +'%d')
-NOTE_DIR="$HOME/notes/$YEAR/$MONTH"
-NOTE_NAME="$DAY.md"
+NOTE_DIR="$HOME/notes"
+NOTE_NAME="$YEAR-$MONTH-$DAY.md"
 
 NOTERC="${XDG_CONFIG_HOME:-$HOME/.config}/notekeeper/noterc"
 if [ -f "$NOTERC" ]; then source "$NOTERC"; fi
+
+NOTE_DIR="$NOTE_DIR/$YEAR/$MONTH/$DAY"
 
 create_note() {
     if [ ! -f "$NOTE_DIR/$NOTE_NAME" ]; then


### PR DESCRIPTION
- Changes the directory structure for notes.
- Changes default note name from `$DAY.md` to `$YEAR-$MONTH-$DAY.md`
- Improve README and `noterc` file documentation.


Old: `$NOTE_DIR/year/month/day.md`
New: `$NOTE_DIR/year/month/day/note.md`

This is done in order to better handle multiple notes. With v0.4 we introduced the ability to have multiple notes for a single day (via the `-n | --name` flag). 