### PR TITLE
Use bash version specified in users environment

### DIFF
--- a/note
+++ b/note
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # shellcheck source="${XDG_CONFIG_HOME:-$HOME/.config}/notekeeper/noterc"
 # shellcheck disable=SC1091


### PR DESCRIPTION
`#!/bin/bash` --> `#!/usr/bin/env bash`

Useful if you prefer to use a version of bash not installed by default on your system. Especially useful for Mac OS users (since Mac OS still ships with a ~15 year old version of bash).