### PR TITLE
Handle arguments better

### DIFF
--- a/note
+++ b/note
@@ -6,9 +6,12 @@
 YEAR=$(date +'%Y')
 MONTH=$(date +'%m')
 DAY=$(date +'%d')
+
+# Set default configuration
 NOTE_DIR="$HOME/notes"
 NOTE_NAME="$YEAR-$MONTH-$DAY.md"
 
+# Overwrite configs from noterc configuration file
 NOTERC="${XDG_CONFIG_HOME:-$HOME/.config}/notekeeper/noterc"
 if [ -f "$NOTERC" ]; then source "$NOTERC"; fi
 
@@ -87,7 +90,7 @@ if (($# > 0)); then
             ;;
         -p | --print)
             cat "$NOTE_DIR/$NOTE_NAME"
-            shift
+            exit 0
             ;;
         -c | --create)
             createNoteOnly=true

--- a/note
+++ b/note
@@ -106,7 +106,7 @@ if (($# > 0)); then
             ;;
         -h | --help)
             print_help
-            shift
+            exit 0
             ;;
         -t | --time)
             addTimeStamp=true

--- a/note
+++ b/note
@@ -79,6 +79,8 @@ open_note() {
 }
 
 openNote=false
+printNoteOnly=false
+createNoteOnly=false
 
 if (($# > 0)); then
     while [[ $# -gt 0 ]]; do
@@ -89,8 +91,8 @@ if (($# > 0)); then
             exit 0
             ;;
         -p | --print)
-            cat "$NOTE_DIR/$NOTE_NAME"
-            exit 0
+            printNoteOnly=true
+            shift
             ;;
         -c | --create)
             createNoteOnly=true
@@ -119,14 +121,18 @@ if (($# > 0)); then
         *)
             printf "Unknown Argument \"%s\"\n" "$1"
             printf "Use \"note --help\" to see usage information.\n"
-            shift
+            exit 1
             ;;
         esac
     done
 else
     openNote=true
 fi
-  #statements
+
+if [ "$printNoteOnly" = true ]; then
+    cat "$NOTE_DIR/$NOTE_NAME"
+    exit 0
+fi
 
 if [ "$createNoteOnly" = true ]; then
     create_note


### PR DESCRIPTION
General improvements to argument-handling + allows arguments to work better with custom named notes. 

e.g. you can now do:

- `note -h` will print help and exit immediately.
- Both `-c` and `-p` flags are compatible with `-n`.
  - `note -p -n mynote.md` will print out the contents of `mynote.md`, not the default note.
  - `nope -c -n mynote.md` will create the note `mynote.md`, not a default note.
- `-c` and `-p` flags are not compatible with eachother, whichever is listed first will be the one accepted.
