### PR TITLE
Add ability to set a preferred print tool other than cat

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,6 @@ The following variables can be set to overwrite Notekeeper defaults:
 
 * `NOTE_NAME`
   * Default is `$YEAR-$MONTH-$DAY.md`
+
+# `PRINT_TOOL`
+  * Default is `cat`

--- a/note
+++ b/note
@@ -10,6 +10,7 @@ DAY=$(date +'%d')
 # Set default configuration
 NOTE_DIR="$HOME/notes"
 NOTE_NAME="$YEAR-$MONTH-$DAY.md"
+PRINT_TOOL="cat"
 
 # Overwrite configs from noterc configuration file
 NOTERC="${XDG_CONFIG_HOME:-$HOME/.config}/notekeeper/noterc"
@@ -114,7 +115,7 @@ else
 fi
 
 if [ "$printNoteOnly" = true ]; then
-    cat "$NOTE_DIR/$NOTE_NAME"
+    $PRINT_TOOL "$NOTE_DIR/$NOTE_NAME"
     exit 0
 fi
 


### PR DESCRIPTION
Add `PRINT_TOOL` variable set to `cat` by default.
- Can customize the `PRINT_TOOL` in `noterc` configuration file.