### PR TITLE
feat: Add ability to configure note-path and organize notes in a date-based directory structure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ You can use a `noterc` file to customize Notekeeper!
 
 - Create this file at `${XDG_CONFIG_HOME}/notekeeper/noterc`
   - On MacOS, this will be `~/.config/notekeeper/noterc`
+- [Example noterc file](https://github.com/dcchambers/dotfiles/blob/master/.config/notekeeper/noterc)
 
 The following variables can be set to overwrite Notekeeper defaults:
 
@@ -109,6 +110,9 @@ The following variables can be set to overwrite Notekeeper defaults:
   - The default is `$YEAR-$MONTH-$DAY.md`
 - `PRINT_TOOL`
   - Default is `cat`
+- `organize_by_date`
+  - Default is `true`. Set `organize_by_date=false` if you do not want to use a date-based
+    directory structure for organizing notes.
 
 ## Dependencies
 

--- a/note.bash
+++ b/note.bash
@@ -35,7 +35,7 @@ create_note() {
 }
 
 print_help() {
-    printf "Notekeeper 1.0 (31 March 2021)
+    printf "Notekeeper 1.1 (11 May 2021)
 
 Usage: note [<args>]
 

--- a/note.bash
+++ b/note.bash
@@ -46,7 +46,7 @@ Arguments:
        --destroy <FILENAME>           Permanently delete (rm) a note.
 
 Notekeeper loads configuration variables from:
-\$HOME/.config}/notekeeper/noterc.
+\$HOME/.config/notekeeper/noterc.
 
 For more help, see: https://github.com/dcchambers/note-keeper\n"
 }

--- a/note.bash
+++ b/note.bash
@@ -9,7 +9,6 @@ DAY=$(date +'%d')
 
 # Set default configuration
 NOTE_DIR="$HOME/notes"
-BASE_NOTE_DIR=$NOTE_DIR
 NOTE_NAME="$YEAR-$MONTH-$DAY.md"
 PRINT_TOOL="cat"
 
@@ -17,6 +16,7 @@ PRINT_TOOL="cat"
 NOTERC="${XDG_CONFIG_HOME:-$HOME/.config}/notekeeper/noterc"
 if [ -f "$NOTERC" ]; then source "$NOTERC"; fi
 
+BASE_NOTE_DIR=$NOTE_DIR
 NOTE_DIR="$NOTE_DIR/$YEAR/$MONTH/$DAY"
 
 create_note() {

--- a/note.bash
+++ b/note.bash
@@ -11,20 +11,26 @@ DAY=$(date +'%d')
 NOTE_DIR="$HOME/notes"
 NOTE_NAME="$YEAR-$MONTH-$DAY.md"
 PRINT_TOOL="cat"
+organize_by_date=true
 
 # Overwrite default configs from noterc configuration file
 NOTERC="${XDG_CONFIG_HOME:-$HOME/.config}/notekeeper/noterc"
 if [ -f "$NOTERC" ]; then source "$NOTERC"; fi
 
 BASE_NOTE_DIR=$NOTE_DIR
-NOTE_DIR="$NOTE_DIR/$YEAR/$MONTH/$DAY"
+if [ "$organize_by_date" = true ]; then
+    NOTE_PATH="$NOTE_DIR/$YEAR/$MONTH/$DAY"
+else
+    NOTE_PATH=$NOTE_DIR
+fi
+
 
 create_note() {
-    if [ ! -f "$NOTE_DIR/$NOTE_NAME" ]; then
-        mkdir -p "$NOTE_DIR"
-        touch "$NOTE_DIR/$NOTE_NAME"
-        printf "%s-%s-%s\n---\n\n" "$DAY" "$MONTH" "$YEAR" > "$NOTE_DIR/$NOTE_NAME"
-        printf "Created new note: %s/%s\n" "$NOTE_DIR" "$NOTE_NAME"
+    if [ ! -f "$NOTE_PATH/$NOTE_NAME" ]; then
+        mkdir -p "$NOTE_PATH"
+        touch "$NOTE_PATH/$NOTE_NAME"
+        printf "%s-%s-%s\n---\n\n" "$DAY" "$MONTH" "$YEAR" > "$NOTE_PATH/$NOTE_NAME"
+        printf "Created new note: %s/%s\n" "$NOTE_PATH" "$NOTE_NAME"
     fi
 }
 
@@ -208,11 +214,11 @@ else
 fi
 
 if [ "$printNoteOnly" = true ]; then
-    if [ ! -f "$NOTE_DIR/$NOTE_NAME" ]; then
-      printf "Unable to find a note to print in directory: %s\n" "$NOTE_DIR"
+    if [ ! -f "$NOTE_PATH/$NOTE_NAME" ]; then
+      printf "Unable to find a note to print in directory: %s\n" "$NOTE_PATH"
       exit 1
     fi
-    $PRINT_TOOL "$NOTE_DIR/$NOTE_NAME"
+    $PRINT_TOOL "$NOTE_PATH/$NOTE_NAME"
     exit 0
 fi
 
@@ -222,10 +228,10 @@ if [ "$createNoteOnly" = true ]; then
 fi
 
 if [ "$addTimeStamp" = true ]; then
-    printf "[%s]\n" "$(date +%T)" >> "$NOTE_DIR/$NOTE_NAME"
+    printf "[%s]\n" "$(date +%T)" >> "$NOTE_PATH/$NOTE_NAME"
 fi
 
 if [ "$openNote" = true ]; then
     create_note
-    open_note "$NOTE_DIR/$NOTE_NAME"
+    open_note "$NOTE_PATH/$NOTE_NAME"
 fi


### PR DESCRIPTION
- New `noterc` variable: `organize_by_date`.
  - Default is `true`. Set to `false` if you don't want to use `.../$YEAR/$MONTH/$DAY/...` structure to organize notes.
- Fixed a typo in the usage/help print.
- Fixed a bug with custom note directories set in `noterc`
- Updated README with above information.