### PR TITLE
Feat: Add ability to list notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ and will open that note file in Vim.
   - Use the `-d` flag to move a file into trash (`$NOTE_DIR/trash`)
 - `--destroy <FILENAME>`
   - Use the `--destroy` flag to permanently delete a note.
+- `-l | --list [<FILE EXTENSION>]`
+  - Use this `--list` flag to list note files. Defaults to `.md` files if no extension is specified.
 
 ## Demo (Asciinema)
 

--- a/note.bash
+++ b/note.bash
@@ -136,9 +136,7 @@ destroy_note() {
 }
 
 list_notes() {
-    for note in $(ls -1 -R $NOTE_DIR | grep "$1"); do
-        printf "$note\n"
-    done
+    find "$BASE_NOTE_DIR" -type f -name "*$1" | sed "s@.*/@@" | sort
 }
 
 openNote=false

--- a/note.bash
+++ b/note.bash
@@ -35,7 +35,7 @@ create_note() {
 }
 
 print_help() {
-    printf "Notekeeper 1.1 (11 May 2021)
+    printf "Notekeeper 1.2 (10 November 2021)
 
 Usage: note [<args>]
 
@@ -50,6 +50,8 @@ Arguments:
   -t | --time                         Add a timestamp when opening a note.
   -d | --delete  <FILENAME>           Move a note to the trash directory.
        --destroy <FILENAME>           Permanently delete (rm) a note.
+  -l | --list   [<File Extension>]    List note files. Defaults to .md files
+                                      if no file extension is specified.
 
 Notekeeper loads configuration variables from:
 \$HOME/.config/notekeeper/noterc.
@@ -133,6 +135,12 @@ destroy_note() {
     fi
 }
 
+list_notes() {
+    for note in $(ls -1 -R $NOTE_DIR | grep "$1"); do
+        printf "$note\n"
+    done
+}
+
 openNote=false
 printNoteOnly=false
 createNoteOnly=false
@@ -199,6 +207,15 @@ if (($# > 0)); then
                 exit 1
             fi
             destroy_note "$2"
+            exit 0
+            ;;
+        -l | --list)
+            if [ "$#" -eq 2 ]; then
+                file_extension=$2
+            else
+                file_extension=".md"
+            fi
+            list_notes $file_extension
             exit 0
             ;;
         *)


### PR DESCRIPTION
- Adds the ability to list notes using the `-l | --list` flag.
  - Optionally takes a file extension argument.
    - Defaults to `.md` if no extension type is given.
- Add usage to `--help` and `README`.
- Bump version to 1.2
- Lists the note files **without** file path.
 

Resolves #54 