### PR TITLE
docs: Add aur package maintainer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ brew tap dcchambers/tap
 brew update && brew install notekeeper
 ```
 ### Arch Linux
-
+- Maintained by [Luis Pérez](https://github.com/luisperezmarin) - thank you!
 ```
 paru -S notekeeper
 ```


### PR DESCRIPTION
Add @luisperezmarin as the maintainer of the [notekeeper aur package](https://aur.archlinux.org/packages/notekeeper/).

Thanks!