### PR TITLE
feat: add ability to customize note file format

### DIFF
--- a/note.bash
+++ b/note.bash
@@ -9,7 +9,8 @@ DAY=$(date +'%d')
 
 # Set default configuration
 NOTE_DIR="$HOME/notes"
-NOTE_NAME="$YEAR-$MONTH-$DAY.md"
+NOTE_FORMAT="md"
+NOTE_NAME="$YEAR-$MONTH-$DAY.$NOTE_FORMAT"
 PRINT_TOOL="cat"
 organize_by_date=true
 
@@ -176,6 +177,10 @@ if (($# > 0)); then
             if [ -z "$NOTE_NAME" ]; then
                 printf "Expected additional argument <Note Filename>.\n"
                 exit 1
+            fi
+            pattern='\.[^.]+$'
+            if ! [[ "$NOTE_NAME" =~ $pattern ]]; then
+              NOTE_NAME="$NOTE_NAME.$NOTE_FORMAT"
             fi
             shift
             shift


### PR DESCRIPTION
- Add `NOTE_FORMAT` configuration option. The default is markdown (.md)
- Newly created notes in the standard date format will end in this file extension.
- Newly created notes named with the `-n` option will default to this format only if they do not have a specified extension.
  - For example, `note -n my-note.md` will create the note `my-note.md`, and `note -n my-other-note` will create the note `my-other-note.md`